### PR TITLE
Add task commenting functionality via add_comment_task tool

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -561,7 +561,7 @@ const DELETE_DOC_TOOL: Tool = {
 };
 
 const ADD_TASK_COMMENT_TOOL: Tool = {
-  name: "add_comment_task",
+  name: "add_task_comment",
   description:
     "Add a comment/note to an existing task without modifying the task description. Comments support markdown formatting.",
   inputSchema: {

--- a/index.ts
+++ b/index.ts
@@ -563,7 +563,7 @@ const DELETE_DOC_TOOL: Tool = {
 const ADD_TASK_COMMENT_TOOL: Tool = {
   name: "add_task_comment",
   description:
-    "Add a comment/note to an existing task without modifying the task description. Comments support markdown formatting.",
+    "Add a comment to an existing task without modifying the task description. Comments support markdown formatting.",
   inputSchema: {
     type: "object",
     properties: {

--- a/index.ts
+++ b/index.ts
@@ -560,7 +560,7 @@ const DELETE_DOC_TOOL: Tool = {
   },
 };
 
-const ADD_COMMENT_TASK_TOOL: Tool = {
+const ADD_TASK_COMMENT_TOOL: Tool = {
   name: "add_comment_task",
   description:
     "Add a comment/note to an existing task without modifying the task description. Comments support markdown formatting.",

--- a/index.ts
+++ b/index.ts
@@ -737,7 +737,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     GET_TASK_TOOL,
     UPDATE_TASK_TOOL,
     DELETE_TASK_TOOL,
-    ADD_COMMENT_TASK_TOOL,
+    ADD_TASK_COMMENT_TOOL,
     LIST_DOCS_TOOL,
     CREATE_DOC_TOOL,
     GET_DOC_TOOL,

--- a/index.ts
+++ b/index.ts
@@ -419,6 +419,28 @@ const DELETE_TASK_TOOL: Tool = {
   },
 };
 
+const ADD_TASK_COMMENT_TOOL: Tool = {
+  name: "add_task_comment",
+  description:
+    "Add a comment to an existing task without modifying the task description. Comments support markdown formatting.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      taskId: {
+        type: "string",
+        description: "The 12-character alphanumeric ID of the task",
+        pattern: "^[a-zA-Z0-9]{12}$",
+      },
+      text: {
+        type: "string",
+        description:
+          "The full content of the comment, which can include markdown formatting.",
+      },
+    },
+    required: ["taskId", "text"],
+  },
+};
+
 const LIST_DOCS_TOOL: Tool = {
   name: "list_docs",
   description:
@@ -557,27 +579,6 @@ const DELETE_DOC_TOOL: Tool = {
       },
     },
     required: ["id"],
-  },
-};
-
-const ADD_TASK_COMMENT_TOOL: Tool = {
-  name: "add_task_comment",
-  description:
-    "Add a comment to an existing task without modifying the task description. Comments support markdown formatting.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      taskId: {
-        type: "string",
-        description: "The 12-character alphanumeric ID of the task",
-        pattern: "^[a-zA-Z0-9]{12}$",
-      },
-      text: {
-        type: "string",
-        description: "The full content of the comment, which can include markdown formatting",
-      },
-    },
-    required: ["taskId", "text"],
   },
 };
 

--- a/index.ts
+++ b/index.ts
@@ -796,7 +796,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           content: [{ type: "text", text: JSON.stringify(task, null, 2) }],
         };
       }
-      case "add_comment_task": {
+      case "add_task_comment": {
         const taskId = getIdValidated(request.params.arguments.taskId);
         const text = request.params.arguments.text;
         const commentData = { taskId, text } as CommentCreate;

--- a/index.ts
+++ b/index.ts
@@ -574,7 +574,7 @@ const ADD_TASK_COMMENT_TOOL: Tool = {
       },
       text: {
         type: "string",
-        description: "The comment text (supports markdown formatting)",
+        description: "The full content of the comment, which can include markdown formatting",
       },
     },
     required: ["taskId", "text"],


### PR DESCRIPTION
A simple pr to add a add_comment_task tool to the mcp server that allows the an llm to add a comment to a task.

![image](https://github.com/user-attachments/assets/a22ec138-4055-4e54-aee9-c82e7ea026d3)
