### PR TITLE
Fix MCP Docker container multiplication when used with Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,11 @@ If the `npx` setup above does not work well, we also provide a Docker setup. Fol
    {
      "mcpServers": {
        "dart": {
-         "command": "docker",
-         "args": ["run", "-i", "--rm", "-e", "DART_TOKEN", "mcp/dart"],
+         "command": "bash",
+         "args": [
+           "-c",
+           "docker stop dart-mcp >/dev/null 2>&1 || true; docker rm -f dart-mcp >/dev/null 2>&1 || true; docker run -i --rm --name dart-mcp -e DART_TOKEN mcp/dart"
+          ],
          "env": {
            "DART_TOKEN": "dsa_..."
          }

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ If the `npx` setup above does not work well, we also provide a Docker setup. Fol
          "command": "bash",
          "args": [
            "-c",
-           "docker stop dart-mcp >/dev/null 2>&1 || true; docker rm -f dart-mcp >/dev/null 2>&1 || true; docker run -i --rm --name dart-mcp -e DART_TOKEN mcp/dart"
+           "docker rm -f dart-mcp >/dev/null 2>&1 || true; docker run -i --rm --name dart-mcp -e DART_TOKEN mcp/dart"
           ],
          "env": {
            "DART_TOKEN": "dsa_..."


### PR DESCRIPTION
## Problem
Users reported multiple instances of `mcp/dart` containers being created when:
- System wakes from sleep
- Switching between Claude Desktop tabs (Chats, Projects)
- Starting new chats
- After system reboots

## Changes
- Added container name specification (`--name dart-mcp`)
- Added pre-start cleanup command:
  ```bash
  docker rm -f dart-mcp >/dev/null 2>&1 || true
  ```